### PR TITLE
IsInstalled{,Version} didn't check all the pkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ import (
 	"github.com/milosgajdos83/servpeek/resource/pkg"
 )
 
-func Test_Gem_Package(t *testing.T) {
+func TestGemPackage(t *testing.T) {
 	testPkg := resource.Pkg{
 		Name:    "bundler",
 		Version: "1.10.6",
 		Type:    "gem",
 	}
 
-	if err := pkg.IsInstalled(testPkg); err !=nil {
+	if err := pkg.IsInstalledVersion(testPkg); err !=nil {
 		t.Errorf("Error: %s", err)
 	}
 }


### PR DESCRIPTION
There was a bug that was avoiding the check of all the installed
packages & versions.

For the sake of simplicity a new version const was added that prevents
the version checking. Ex: if the version is set to "*" it means that the
version doesn't matter.