### PR TITLE
Make the package go gettable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # servpeek
 
+[![GoDoc](https://godoc.org/github.com/milosgajdos83/servpeek?status.svg)](https://godoc.org/github.com/milosgajdos83/servpeek)
+
 Introspective peek into your server guts
 
 ## Motivation

--- a/main.go
+++ b/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
Having a go gettable package will make it more easy to use the go
tooling. For example, we can use godoc now.