### PR TITLE
Close lines before read + properly change version matcher

### DIFF
--- a/resource/pkg/pkg.go
+++ b/resource/pkg/pkg.go
@@ -16,10 +16,12 @@ const AllVersions = "*"
 // IsInstalled returns nil if the package was found. Otherwise it will return
 // an error.
 func IsInstalled(pkgs ...resource.Pkg) error {
+	var ignoreVersionPkgs []resource.Pkg
 	for _, p := range pkgs {
 		p.Version = AllVersions
+		ignoreVersionPkgs = append(ignoreVersionPkgs, p)
 	}
-	return IsInstalledVersion(pkgs...)
+	return IsInstalledVersion(ignoreVersionPkgs...)
 }
 
 // IsInstalledVersion returns nil if the versions of the given package were

--- a/utils/command/command.go
+++ b/utils/command/command.go
@@ -32,12 +32,15 @@ func (c *Command) Run() *Out {
 		reader: cmdStdout,
 		err:    err,
 	}
-	defer close(res.lines)
+
 	if err != nil {
+		close(res.lines)
 		return res
 	}
 
 	go func() {
+		defer close(res.lines)
+
 		if err := cmd.Start(); err != nil {
 			res.mu.Lock()
 			defer res.mu.Unlock()


### PR DESCRIPTION
There was a bug with non properly closed res.lines that was causing the
parser to behave weirdly.

Also, the change of version from the original string to an start (to
match all) was not being persisted in the call because of the context
where it was happening.