### PR TITLE
Fixes a bug when multiple versions of a package are installed

### DIFF
--- a/pkg/gem.go
+++ b/pkg/gem.go
@@ -15,11 +15,11 @@ var (
 	// gem package manager parser hints
 	gemListPkgsOutHints = &hints{
 		filter:  regexp.MustCompile(`^[A-Za-z]`),
-		matcher: regexp.MustCompile(`^(\S+)\s+\((\S+)\)$`),
+		matcher: regexp.MustCompile(`^(\S+)\s+\((.+)\)$`),
 	}
 	gemQueryPkgsOutHints = &hints{
 		filter:  regexp.MustCompile(`^[A-Za-z]`),
-		matcher: regexp.MustCompile(`^\S+\s+\((\S+)\)$`),
+		matcher: regexp.MustCompile(`^\S+\s+\((.+)\)$`),
 	}
 )
 

--- a/pkg/manager.go
+++ b/pkg/manager.go
@@ -11,9 +11,11 @@ type Manager interface {
 	// Type returns the type of the package the manager maintains
 	Type() string
 	// ListPkgs allows to list all installed packages on the system
+	// It returns a list of all installed packages found in package database
 	// It returns error if the installed packages can't be listed
 	ListPkgs() ([]Pkg, error)
 	// QueryPkg queries package database about particular package
+	// It returns a list of packages that match the name provided as argument
 	// It returns error if the requested package fails to be queried
 	QueryPkg(pkgName string) ([]Pkg, error)
 }

--- a/pkg/matchers.go
+++ b/pkg/matchers.go
@@ -4,7 +4,7 @@ package pkg
 import "fmt"
 
 // IsInstalled checks if all the packages passed in as parameters are installed
-// with the required version. If pkg.Version() returns empty string, version check is ignored
+// If pkg.Versions() returns empty list, package version check is ignored
 // IsInstalled returns error if at least one supplied package is not installed
 // or if it's verstion is different from the required version.
 func IsInstalled(pkgs ...Pkg) error {
@@ -18,21 +18,21 @@ func IsInstalled(pkgs ...Pkg) error {
 			return fmt.Errorf("Unable to look up %s: no package found", p)
 		}
 
-		if p.Version() == nil {
+		if p.Versions() == nil {
 			continue
 		}
 
 	CheckPkgs:
 		for _, foundPkg := range foundPkgs {
-			for _, foundPkgVersion := range foundPkg.Version() {
-				for _, pkgVersion := range p.Version() {
+			for _, foundPkgVersion := range foundPkg.Versions() {
+				for _, pkgVersion := range p.Versions() {
 					if foundPkgVersion == pkgVersion {
 						break CheckPkgs
 					}
 				}
 			}
 			return fmt.Errorf("Requested package versions: %v, found: %v",
-				p.Version(), foundPkg.Version())
+				p.Versions(), foundPkg.Versions())
 		}
 	}
 	return nil

--- a/pkg/matchers.go
+++ b/pkg/matchers.go
@@ -18,15 +18,21 @@ func IsInstalled(pkgs ...Pkg) error {
 			return fmt.Errorf("Unable to look up %s: no package found", p)
 		}
 
-		if p.Version() == "" {
+		if p.Version() == nil {
 			continue
 		}
 
+	CheckPkgs:
 		for _, foundPkg := range foundPkgs {
-			if foundPkg.Version() == p.Version() {
-				continue
+			for _, foundPkgVersion := range foundPkg.Version() {
+				for _, pkgVersion := range p.Version() {
+					if foundPkgVersion == pkgVersion {
+						break CheckPkgs
+					}
+				}
 			}
-			return fmt.Errorf("Incorrect package version found: %s", foundPkg.Version())
+			return fmt.Errorf("Requested package versions: %v, found: %v",
+				p.Version(), foundPkg.Version())
 		}
 	}
 	return nil

--- a/pkg/matchers_test.go
+++ b/pkg/matchers_test.go
@@ -16,18 +16,18 @@ func TestIsInstalled(t *testing.T) {
 		{"apt", "cron", "3.0pl1-124ubuntu2"},
 		{"yum", "grep", "2.20"},
 		{"apk", "musl-utils", "1.1.11-r2"},
-		{"pip", "setuptools", ""},
+		{"pip", "setuptools", "3.3"},
 		{"gem", "bundler", "1.10.6"},
 	}
 
 	for _, pkg := range pkgs {
-		p, err := newMockPkg(pkg.pkgType, pkg.name, pkg.version, "query")
+		p, err := newMockPkg(pkg.pkgType, pkg.name, "query", pkg.version)
 		assert.NoError(err)
 		assert.NoError(IsInstalled(p))
 	}
 
 	// check package that is not installed
-	p, err := newMockPkg("gem", "randpkg", "", "bogus")
+	p, err := newMockPkg("gem", "randpkg", "bogus", "")
 	assert.NoError(err)
 	assert.Error(IsInstalled(p))
 }

--- a/pkg/mocks_test.go
+++ b/pkg/mocks_test.go
@@ -97,6 +97,6 @@ func newMockPkg(pkgType, pkgName, cmdType string, pkgVersion ...string) (*mockPk
 	}, nil
 }
 
-func (m *mockPkg) Manager() Manager  { return m.manager }
-func (m *mockPkg) Name() string      { return m.name }
-func (m *mockPkg) Version() []string { return m.versions }
+func (m *mockPkg) Manager() Manager   { return m.manager }
+func (m *mockPkg) Name() string       { return m.name }
+func (m *mockPkg) Versions() []string { return m.versions }

--- a/pkg/mocks_test.go
+++ b/pkg/mocks_test.go
@@ -79,24 +79,24 @@ func (m *mockPkgManager) QueryPkg(pkgName string) ([]Pkg, error) {
 }
 
 type mockPkg struct {
-	manager *mockPkgManager
-	name    string
-	version string
+	manager  *mockPkgManager
+	name     string
+	versions []string
 }
 
-func newMockPkg(pkgType, pkgName, pkgVersion, cmdType string) (*mockPkg, error) {
+func newMockPkg(pkgType, pkgName, cmdType string, pkgVersion ...string) (*mockPkg, error) {
 	pkgManager, err := newMockPkgManager(pkgType, cmdType)
 	if err != nil {
 		return nil, err
 	}
 
 	return &mockPkg{
-		manager: pkgManager,
-		name:    pkgName,
-		version: pkgVersion,
+		manager:  pkgManager,
+		name:     pkgName,
+		versions: pkgVersion,
 	}, nil
 }
 
-func (m *mockPkg) Manager() Manager { return m.manager }
-func (m *mockPkg) Name() string     { return m.name }
-func (m *mockPkg) Version() string  { return m.version }
+func (m *mockPkg) Manager() Manager  { return m.manager }
+func (m *mockPkg) Name() string      { return m.name }
+func (m *mockPkg) Version() []string { return m.versions }

--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/milosgajdos83/servpeek/utils/command"
 )
@@ -110,5 +111,10 @@ func parseQueryOut(pkgType, line string, re *regexp.Regexp) (Pkg, error) {
 	if match == nil || len(match) < 2 {
 		return nil, fmt.Errorf("Unable to parse Query package info")
 	}
-	return NewSwPkg(pkgType, "foo", match[1])
+	rawVersions := strings.Split(match[1], ",")
+	var versions []string
+	for _, v := range rawVersions {
+		versions = append(versions, strings.TrimSpace(v))
+	}
+	return NewSwPkg(pkgType, "N/A", versions...)
 }

--- a/pkg/pip.go
+++ b/pkg/pip.go
@@ -15,11 +15,11 @@ var (
 	// pip package manager parser hints
 	pipListPkgsOutHints = &hints{
 		filter:  regexp.MustCompile(`^[A-Za-z]`),
-		matcher: regexp.MustCompile(`^(\S+)\s+\((\S+)\)$`),
+		matcher: regexp.MustCompile(`^(\S+)\s+\((.+)\)$`),
 	}
 	pipQueryPkgsOutHints = &hints{
 		filter:  regexp.MustCompile(`^Version`),
-		matcher: regexp.MustCompile(`^Version\s?:\s+(\S+).*`),
+		matcher: regexp.MustCompile(`^Version\s?:\s+(.+).*`),
 	}
 )
 

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -14,8 +14,8 @@ var supportedPkgTypes = map[string]bool{
 type Pkg interface {
 	// Name returns package name
 	Name() string
-	// Version returns package version
-	Version() string
+	// Version returns slice of all package versions
+	Version() []string
 	// Manager returns package manager
 	Manager() Manager
 }
@@ -29,18 +29,18 @@ type SwPkg struct {
 	// package name
 	name string
 	// package version
-	version string
+	versions []string
 }
 
 // NewSwPkg returns *SwPkg. It returns error if either the requested package type is unsupported
 // or package name passed as parameter is empty string. If version is empty string, it is
 // ignored by matchers
-func NewSwPkg(pkgType, name, version string) (*SwPkg, error) {
+func NewSwPkg(pkgType, pkgName string, pkgVersions ...string) (*SwPkg, error) {
 	if !supportedPkgTypes[pkgType] {
 		return nil, fmt.Errorf("Unsupported package type: %s", pkgType)
 	}
 
-	if name == "" {
+	if pkgName == "" {
 		return nil, fmt.Errorf("Package name can not be empty!")
 	}
 
@@ -50,9 +50,9 @@ func NewSwPkg(pkgType, name, version string) (*SwPkg, error) {
 	}
 
 	return &SwPkg{
-		manager: manager,
-		name:    name,
-		version: version,
+		manager:  manager,
+		name:     pkgName,
+		versions: pkgVersions,
 	}, nil
 }
 
@@ -61,9 +61,10 @@ func (s *SwPkg) Name() string {
 	return s.name
 }
 
-// Version returns package version
-func (s *SwPkg) Version() string {
-	return s.version
+// Version returns a slice of all package versions
+// If the returned slice is nil, no version has been specified
+func (s *SwPkg) Version() []string {
+	return s.versions
 }
 
 // Manager returns package manager that manages this type of package
@@ -73,5 +74,6 @@ func (s *SwPkg) Manager() Manager {
 
 // String implements Stringer interface
 func (s *SwPkg) String() string {
-	return fmt.Sprintf("[SwPkg] Type: %s Name: %s Version: %s", s.manager.Type(), s.name, s.version)
+	return fmt.Sprintf("[SwPkg] Type: %s Name: %s Version: %v",
+		s.manager.Type(), s.name, s.versions)
 }

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -14,8 +14,8 @@ var supportedPkgTypes = map[string]bool{
 type Pkg interface {
 	// Name returns package name
 	Name() string
-	// Version returns slice of all package versions
-	Version() []string
+	// Versions returns slice of all package versions
+	Versions() []string
 	// Manager returns package manager
 	Manager() Manager
 }
@@ -63,7 +63,7 @@ func (s *SwPkg) Name() string {
 
 // Version returns a slice of all package versions
 // If the returned slice is nil, no version has been specified
-func (s *SwPkg) Version() []string {
+func (s *SwPkg) Versions() []string {
 	return s.versions
 }
 

--- a/pkg/pkg_test.go
+++ b/pkg/pkg_test.go
@@ -13,7 +13,7 @@ func TestPkg(t *testing.T) {
 	assert.NoError(err)
 
 	expected := fmt.Sprintf("[SwPkg] Type: %s Name: %s Version: %v",
-		p.Manager().Type(), p.Name(), p.Version())
+		p.Manager().Type(), p.Name(), p.Versions())
 	assert.Equal(expected, p.String())
 }
 
@@ -41,11 +41,11 @@ func TestName(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestVersion(t *testing.T) {
+func TestVersions(t *testing.T) {
 	tstVersion := "0.1.1"
 	assert := assert.New(t)
 	p, err := NewSwPkg("pip", "PkgName", tstVersion)
 	assert.NoError(err)
 	versions := []string{tstVersion}
-	assert.Equal(versions, p.Version())
+	assert.Equal(versions, p.Versions())
 }

--- a/pkg/pkg_test.go
+++ b/pkg/pkg_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,8 @@ func TestPkg(t *testing.T) {
 	p, err := NewSwPkg("gem", "PkgName", "0.1.1")
 	assert.NoError(err)
 
-	expected := "[SwPkg] Type: " + p.Manager().Type() + " Name: " + p.Name() + " Version: " + p.Version()
+	expected := fmt.Sprintf("[SwPkg] Type: %s Name: %s Version: %v",
+		p.Manager().Type(), p.Name(), p.Version())
 	assert.Equal(expected, p.String())
 }
 
@@ -44,5 +46,6 @@ func TestVersion(t *testing.T) {
 	assert := assert.New(t)
 	p, err := NewSwPkg("pip", "PkgName", tstVersion)
 	assert.NoError(err)
-	assert.Equal(tstVersion, p.Version())
+	versions := []string{tstVersion}
+	assert.Equal(versions, p.Version())
 }

--- a/pkg/test-fixtures/gem-query.out
+++ b/pkg/test-fixtures/gem-query.out
@@ -1,4 +1,4 @@
 
 *** LOCAL GEMS ***
 
-bundler (1.10.6)
+bundler (1.11.2, 1.10.6)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -14,10 +14,7 @@ func TestBuildCmd(t *testing.T) {
 	cmd := "foo"
 	args := []string{"bar"}
 	actCmd := BuildCmd(cmd, args...)
-	expCmd := &command.Cmd{
-		Cmd:  cmd,
-		Args: args,
-	}
+	expCmd := command.NewCommand(cmd, args...)
 	assert.Exactly(t, expCmd, actCmd)
 }
 


### PR DESCRIPTION
Previously when you had multiple version of a same package installed
servpeek would fail to parse query command output (thanks `gem`). This should be fixed now.
The fix brings an interesting benefit: if you're not interested in the
version of a package when querying it, you can simply ignore the last argument of `NewSwPkg`
function. This PR also hides `Cmd` fields to avoid situations when external package clients mess around with them during command execution.